### PR TITLE
Add dependency on React pod

### DIFF
--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
 
   s.source_files  = "RNDeviceInfo/*.{h,m}"
 
+  s.dependency 'React'
 end


### PR DESCRIPTION
With use_frameworks! enabled in my PodFile, I get a linker error:

Undefined symbols for architecture x86_64:
  "_RCTRegisterModule", referenced from:
      +[RNDeviceInfo load] in RNDeviceInfo.o
ld: symbol(s) not found for architecture x86_64

This is fixed by adding React as a dependency in the podspec