### PR TITLE
Add user defined deviceName field

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -132,6 +132,7 @@ RCT_EXPORT_MODULE()
              @"systemVersion": currentDevice.systemVersion,
              @"model": self.deviceName,
              @"deviceId": self.deviceId,
+             @"deviceName": currentDevice.name,
              @"uniqueId": uniqueId,
              @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
              @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.learnium.RNDeviceInfo">
+          
+          <uses-permission android:name="android.permission.BLUETOOTH"/>
 
 </manifest>

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -48,7 +48,17 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     } catch (PackageManager.NameNotFoundException e) {
       e.printStackTrace();
     }
+    
+    String deviceName = "Unknown";
+  
+    try {
+      BluetoothAdapter myDevice = BluetoothAdapter.getDefaultAdapter();
+      deviceName = myDevice.getName();
+    } catch(Exception e) {
+      e.printStackTrace();
+    }
 
+    constants.put("deviceName", deviceName);
     constants.put("systemName", "Android");
     constants.put("systemVersion", Build.VERSION.RELEASE);
     constants.put("model", Build.MODEL);

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -34,5 +34,8 @@ module.exports = {
   },
   getReadableVersion: function() {
     return RNDeviceInfo.appVersion + "." + RNDeviceInfo.buildNumber;
+  },
+  getDeviceName: function() {
+    return RNDeviceInfo.deviceName;
   }
 };


### PR DESCRIPTION
I needed to get the user defined device name for my project so I made these changes to allow for it.

They have the unfortunate side effect of requiring the Bluetooth permission on Android so I don't think this pull request should necessarily be accepted but its here if someone needs/wants it.