### PR TITLE
Set lint warning for InvalidPackage, instead of error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,9 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
+    lintOptions {
+       warning 'InvalidPackage'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Reference:
https://github.com/square/okio/issues/58