### PR TITLE
Add UserAgent as an available bit of information

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,6 @@ console.log("App Version (Readable)", DeviceInfo.getReadableVersion());  // e.g.
 
 console.log("Device Name", DeviceInfo.getDeviceName());  // e.g. Becca's iPhone 6
 
+console.log("User Agent", DeviceInfo.getUserAgent()); // e.g. Dalvik/2.1.0 (Linux; U; Android 5.1; Google Nexus 4 - 5.1.0 - API 22 - 768x1280 Build/LMY47D)
+
 ```

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -122,8 +122,8 @@ RCT_EXPORT_MODULE()
 
 - (NSString*) userAgent
 {
-	UIWebView *webView = [[UIWebView alloc] initiWithFrame:CGRectZero];
-	return [webView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    UIWebView* webView = [[UIWebView alloc] initWithFrame:CGRectZero];
+    return [webView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
 }
 
 - (NSDictionary *)constantsToExport

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -120,6 +120,12 @@ RCT_EXPORT_MODULE()
     return deviceName;
 }
 
+- (NSString*) userAgent
+{
+	UIWebView *webView = [[UIWebView alloc] initiWithFrame:CGRectZero];
+	return [webView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+}
+
 - (NSDictionary *)constantsToExport
 {
     UIDevice *currentDevice = [UIDevice currentDevice];
@@ -138,6 +144,7 @@ RCT_EXPORT_MODULE()
              @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
              @"buildNumber": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
              @"systemManufacturer": @"Apple",
+             @"userAgent": self.userAgent,
              };
 }
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -67,6 +67,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("uniqueId", Secure.getString(this.reactContext.getContentResolver(), Secure.ANDROID_ID));
     constants.put("systemManufacturer", Build.MANUFACTURER);
     constants.put("bundleId", packageName);
+    constants.put("userAgent", System.getProperty("http.agent"));
     return constants;
   }
 }

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -37,5 +37,8 @@ module.exports = {
   },
   getDeviceName: function() {
     return RNDeviceInfo.deviceName;
+  },
+  getUserAgent: function() {
+    return RNDeviceInfo.userAgent;
   }
 };


### PR DESCRIPTION
I had a need to get the OS's UserAgent string. I didn't see any way to pull it from React Native directly so I figured the library that provides device info would make the most sense. 