### PR TITLE
Avoid destructuring to support Node.js

### DIFF
--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -2,7 +2,7 @@
  * @providesModule react-native-device-info
  */
 
-var { RNDeviceInfo } = require('react-native').NativeModules;
+var RNDeviceInfo = require('react-native').NativeModules.RNDeviceInfo;
 
 module.exports = {
   getUniqueID: function () {


### PR DESCRIPTION
Running into an issue when unit testing RN from the CLI. Since [Node doesn't support it yet](https://kangax.github.io/compat-table/es6) it will break. 

```
var { RNDeviceInfo } = require('react-native').NativeModules;
    ^

SyntaxError: Unexpected token {
```