### PR TITLE
Update device names to respect Apple Branding

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -77,8 +77,8 @@ RCT_EXPORT_MODULE()
                               @"iPhone6,2" :@"iPhone 5s",       // (model A1457, A1518, A1528 (China), A1530 | Global)
                               @"iPhone7,1" :@"iPhone 6 Plus",   //
                               @"iPhone7,2" :@"iPhone 6",        //
-                              @"iPhone8,1" :@"iPhone 6S",       //
-                              @"iPhone8,2" :@"iPhone 6S Plus",  //
+                              @"iPhone8,1" :@"iPhone 6s",       //
+                              @"iPhone8,2" :@"iPhone 6s Plus",  //
                               @"iPad4,1"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Wifi
                               @"iPad4,2"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Cellular
                               @"iPad4,3"   :@"iPad Air",        // 5th Generation iPad (iPad Air)


### PR DESCRIPTION
Apple uses lowercase `s` for all devices since 5s model