### PR TITLE
Add support for device country

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -27,9 +27,9 @@ RCT_EXPORT_MODULE()
 - (NSString*) deviceId
 {
     struct utsname systemInfo;
-    
+
     uname(&systemInfo);
-    
+
     return [NSString stringWithCString:systemInfo.machine
                                     encoding:NSUTF8StringEncoding];
 }
@@ -37,9 +37,9 @@ RCT_EXPORT_MODULE()
 - (NSString*) deviceName
 {
     static NSDictionary* deviceNamesByCode = nil;
-    
+
     if (!deviceNamesByCode) {
-        
+
         deviceNamesByCode = @{@"i386"      :@"Simulator",
                               @"x86_64"    :@"Simulator",
                               @"iPod1,1"   :@"iPod Touch",      // (Original)
@@ -100,12 +100,12 @@ RCT_EXPORT_MODULE()
                               @"AppleTV5,3":@"Apple TV",        // Apple TV (4th Generation)
                               };
     }
-    
+
     NSString* deviceName = [deviceNamesByCode objectForKey:self.deviceId];
-    
+
     if (!deviceName) {
         // Not found on database. At least guess main device type from string contents:
-        
+
         if ([self.deviceId rangeOfString:@"iPod"].location != NSNotFound) {
             deviceName = @"iPod Touch";
         }
@@ -132,6 +132,12 @@ RCT_EXPORT_MODULE()
     return language;
 }
 
+- (NSString*) deviceCountry
+{
+  NSString *country = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
+  return country;
+}
+
 - (NSDictionary *)constantsToExport
 {
     UIDevice *currentDevice = [UIDevice currentDevice];
@@ -146,6 +152,7 @@ RCT_EXPORT_MODULE()
              @"deviceId": self.deviceId,
              @"deviceName": currentDevice.name,
              @"deviceLocale": self.deviceLocale,
+             @"deviceCountry": self.deviceCountry,
              @"uniqueId": uniqueId,
              @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
              @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
@@ -156,4 +163,3 @@ RCT_EXPORT_MODULE()
 }
 
 @end
-

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -44,6 +44,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
   }
 
+  private String getCurrentCountry() {
+    Locale current = getReactApplicationContext().getResources().getConfiguration().locale;
+    return current.getCountry();
+  }
+
   @Override
   public @Nullable Map<String, Object> getConstants() {
     HashMap<String, Object> constants = new HashMap<String, Object>();
@@ -77,6 +82,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("model", Build.MODEL);
     constants.put("deviceId", Build.BOARD);
     constants.put("deviceLocale", this.getCurrentLanguage());
+    constants.put("deviceCountry", this.getCurrentCountry());
     constants.put("uniqueId", Secure.getString(this.reactContext.getContentResolver(), Secure.ANDROID_ID));
     constants.put("systemManufacturer", Build.MANUFACTURER);
     constants.put("bundleId", packageName);

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -43,5 +43,8 @@ module.exports = {
   },
   getDeviceLocale: function() {
     return RNDeviceInfo.deviceLocale;
-  }
+  },
+  getDeviceCountry: function() {
+    return RNDeviceInfo.deviceCountry;
+  },
 };


### PR DESCRIPTION
Provides the ISO country string derived from the application's locale.

@rebeccahughes: wasn't sure if this was the best key name; please advise if you'd prefer something different.