### PR TITLE
Add build version

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ console.log("Bundle Id", DeviceInfo.getBundleId());  // e.g. com.learnium.mobile
 
 console.log("Build Number", DeviceInfo.getBuildNumber());  // e.g. 89
 
+console.log("Build Version", DeviceInfo.getBuildVersion());  // on iOS, full build info, e.g. v0.5.9-51-g71ec8a0+
+
 console.log("App Version", DeviceInfo.getVersion());  // e.g. 1.1.0
 
 console.log("App Version (Readable)", DeviceInfo.getReadableVersion());  // e.g. 1.1.0.89

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -160,6 +160,7 @@ RCT_EXPORT_MODULE()
              @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
              @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
              @"buildNumber": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
+             @"buildVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleBuildVersion"],
              @"systemManufacturer": @"Apple",
              @"userAgent": self.userAgent,
              };

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -29,6 +29,9 @@ module.exports = {
   getBuildNumber: function() {
     return RNDeviceInfo.buildNumber;
   },
+  getBuildVersion: function() {
+    return RNDeviceInfo.buildVersion;
+  },
   getVersion: function() {
     return RNDeviceInfo.appVersion;
   },


### PR DESCRIPTION
Returns full build version on iOS, use with [xcode-git-version.sh](https://gist.github.com/karlvr/c93a98d7000ecb163895) to print complete git info.
(Not sure what it'll do on Android)