### PR TITLE
Adding Android's Instance ID 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run `react-native link react-native-device-info` in your project root.
 On React Native 0.18+:
 
 ```java
-import com.learnium.RNDeviceInfo.*;  // <--- import
+import com.learnium.RNDeviceInfo.RNDeviceInfo;  // <--- import
 
 public class MainActivity extends ReactActivity {
   ......

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ public class MainActivity extends ReactActivity {
 
 ## Release Notes
 
- * 0.9.2 add iOS build version
  * 0.9.1 adds support for the iPhone SE and new iPad Pro
  * 0.9.0 adds support for device country and changes the iOS device name to match Apple branding
  * 0.8.4 don't use destructuring
@@ -114,8 +113,6 @@ console.log("Device Version", DeviceInfo.getSystemVersion());  // e.g. 9.0
 console.log("Bundle Id", DeviceInfo.getBundleId());  // e.g. com.learnium.mobile
 
 console.log("Build Number", DeviceInfo.getBuildNumber());  // e.g. 89
-
-console.log("Build Version", DeviceInfo.getBuildVersion());  // (iOS only) full build info, e.g. v0.5.9-51-g71ec8a0+
 
 console.log("App Version", DeviceInfo.getVersion());  // e.g. 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ npm install react-native-device-info --save
 
 ### Installation (iOS)
 
+#### Installing via Cocoa Pods
+Add the following line to your build targets in your `Podfile`
+
+`pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'`
+
+Then run `pod install`
+
+#### Installing manually
+
 In XCode, in the project navigator:
 - Right click Libraries
 - Add Files to [your project's name]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ public class MainActivity extends ReactActivity {
 
 ## Release Notes
 
+ * 0.9.1 adds support for the iPhone SE and new iPad Pro
  * 0.9.0 adds support for device country and changes the iOS device name to match Apple branding
  * 0.8.4 don't use destructuring
  * 0.8.3 removes the default bluetooth permission

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
 
 ## Release Notes
 
+ * 0.8.4 don't use destructuring
  * 0.8.3 removes the default bluetooth permission
  * 0.8.2 change deployment target to iOS 8
  * 0.8.1 removes unnecessary peerDependencies

--- a/README.md
+++ b/README.md
@@ -14,9 +14,16 @@ npm install react-native-device-info --save
 
 ### Installation (iOS)
 
-In XCode, in the project navigator, right click Libraries ➜ Add Files to [your project's name] Go to node_modules ➜ react-native-device-info and add the .xcodeproj file
+In XCode, in the project navigator:
+- Right click Libraries
+- Add Files to [your project's name]
+- Go to node_modules/react-native-device-info
+- Add the .xcodeproj file
 
-In XCode, in the project navigator, select your project. Add the lib*.a from the deviceinfo project to your project's Build Phases ➜ Link Binary With Libraries Click .xcodeproj file you added before in the project navigator and go the Build Settings tab. Make sure 'All' is toggled on (instead of 'Basic'). Look for Header Search Paths and make sure it contains both $(SRCROOT)/../react-native/React and $(SRCROOT)/../../React - mark both as recursive.
+In XCode, in the project navigator, select your project. 
+- Add the libRNDeviceInfo.a from the deviceinfo project to your project's Build Phases ➜ Link Binary With Libraries
+- Click .xcodeproj file you added before in the project navigator and go the Build Settings tab. Make sure 'All' is toggled on (instead of 'Basic').
+- Look for Header Search Paths and make sure it contains both $(SRCROOT)/../react-native/React and $(SRCROOT)/../../React - mark both as recursive. (Should be OK by default.)
 
 Run your project (Cmd+R)
 
@@ -24,27 +31,13 @@ Run your project (Cmd+R)
 
 ### Installation (Android)
 
-* In `android/setting.gradle`
+* Add Gradle configuration changes
 
-```gradle
-...
-include ':RNDeviceInfo', ':app'
-project(':RNDeviceInfo').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-device-info/android')
-```
-
-* In `android/app/build.gradle`
-
-```gradle
-...
-dependencies {
-    ...
-    compile project(':RNDeviceInfo')
-}
-```
+Run `react-native link react-native-device-info` in your project root.
 
 * register module (in MainActivity.java)
 
-On newer versions of React Native (0.18+):
+On React Native 0.18+:
 
 ```java
 import com.learnium.RNDeviceInfo.*;  // <--- import
@@ -62,39 +55,6 @@ public class MainActivity extends ReactActivity {
         new RNDeviceInfo(), // <------ add here
         new MainReactPackage());
     }
-}
-```
-
-On older versions of React Native:
-
-```java
-import com.learnium.RNDeviceInfo.*;  // <--- import
-
-public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {
-  ......
-
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    mReactRootView = new ReactRootView(this);
-
-    mReactInstanceManager = ReactInstanceManager.builder()
-      .setApplication(getApplication())
-      .setBundleAssetName("index.android.bundle")
-      .setJSMainModuleName("index.android")
-      .addPackage(new MainReactPackage())
-      .addPackage(new RNDeviceInfo())              // <------ add here
-      .setUseDeveloperSupport(BuildConfig.DEBUG)
-      .setInitialLifecycleState(LifecycleState.RESUMED)
-      .build();
-
-    mReactRootView.startReactApplication(mReactInstanceManager, "ExampleRN", null);
-
-    setContentView(mReactRootView);
-  }
-
-  ......
-
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In XCode, in the project navigator:
 - Go to node_modules/react-native-device-info
 - Add the .xcodeproj file
 
-In XCode, in the project navigator, select your project. 
+In XCode, in the project navigator, select your project.
 - Add the libRNDeviceInfo.a from the deviceinfo project to your project's Build Phases ➜ Link Binary With Libraries
 - Click .xcodeproj file you added before in the project navigator and go the Build Settings tab. Make sure 'All' is toggled on (instead of 'Basic').
 - Look for Header Search Paths and make sure it contains both $(SRCROOT)/../react-native/React and $(SRCROOT)/../../React - mark both as recursive. (Should be OK by default.)
@@ -69,6 +69,7 @@ public class MainActivity extends ReactActivity {
 
 ## Release Notes
 
+ * 0.9.0 adds support for device country and changes the iOS device name to match Apple branding
  * 0.8.4 don't use destructuring
  * 0.8.3 removes the default bluetooth permission
  * 0.8.2 change deployment target to iOS 8
@@ -109,4 +110,5 @@ console.log("User Agent", DeviceInfo.getUserAgent()); // e.g. Dalvik/2.1.0 (Linu
 
 console.log("Device Locale", DeviceInfo.getDeviceLocale()); // e.g en-US
 
+console.log("Device Country", DeviceInfo.getDeviceCountry()); // e.g US
 ```

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ public class MainActivity extends ReactActivity {
 
 ## Release Notes
 
+ * 0.9.2 add iOS build version
  * 0.9.1 adds support for the iPhone SE and new iPad Pro
  * 0.9.0 adds support for device country and changes the iOS device name to match Apple branding
  * 0.8.4 don't use destructuring
@@ -114,7 +115,7 @@ console.log("Bundle Id", DeviceInfo.getBundleId());  // e.g. com.learnium.mobile
 
 console.log("Build Number", DeviceInfo.getBuildNumber());  // e.g. 89
 
-console.log("Build Version", DeviceInfo.getBuildVersion());  // on iOS, full build info, e.g. v0.5.9-51-g71ec8a0+
+console.log("Build Version", DeviceInfo.getBuildVersion());  // (iOS only) full build info, e.g. v0.5.9-51-g71ec8a0+
 
 console.log("App Version", DeviceInfo.getVersion());  // e.g. 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ console.log("Bundle Id", DeviceInfo.getBundleId());  // e.g. com.learnium.mobile
 
 console.log("Build Number", DeviceInfo.getBuildNumber());  // e.g. 89
 
+console.log("Build Version", DeviceInfo.getBuildVersion());  // on iOS, full build info, e.g. v0.5.9-51-g71ec8a0+
+
 console.log("App Version", DeviceInfo.getVersion());  // e.g. 1.1.0
 
 console.log("App Version (Readable)", DeviceInfo.getReadableVersion());  // e.g. 1.1.0.89

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## MAINTAINERS WANTED!
+
+Unfortunately, I don't have the time to continue maintaining this module. If you would like to take over, please open an issue or get in touch with me (@rebeccahughes).
+
 ## react-native-device-info
 
 [![npm version](https://badge.fury.io/js/react-native-device-info@2x.png)](http://badge.fury.io/js/react-native-device-info)

--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -1,14 +1,15 @@
 Pod::Spec.new do |s|
   s.name         = "RNDeviceInfo"
-  s.version      = "0.4.1"
+  s.version      = "0.9.1"
   s.summary      = "Device Information for react-native"
 
   s.homepage     = "https://github.com/rebeccahughes/react-native-device-info"
 
   s.license      = "MIT"
+  s.authors      = { "Rebecca Hughes" => "rebecca@learnium.net" }
   s.platform     = :ios, "7.0"
 
-  s.source       = { :git => "https://github.com/rebeccahughes/react-native-device-info" }
+  s.source       = { :git => "https://github.com/rebeccahughes/react-native-device-info.git" }
 
   s.source_files  = "RNDeviceInfo/*.{h,m}"
 

--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RNDeviceInfo"
-  s.version      = "0.9.1"
+  s.version      = "0.9.2"
   s.summary      = "Device Information for react-native"
 
   s.homepage     = "https://github.com/rebeccahughes/react-native-device-info"

--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RNDeviceInfo"
-  s.version      = "0.9.2"
+  s.version      = "0.9.3"
   s.summary      = "Device Information for react-native"
 
   s.homepage     = "https://github.com/rebeccahughes/react-native-device-info"

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -27,9 +27,9 @@ RCT_EXPORT_MODULE()
 - (NSString*) deviceId
 {
     struct utsname systemInfo;
-    
+
     uname(&systemInfo);
-    
+
     return [NSString stringWithCString:systemInfo.machine
                                     encoding:NSUTF8StringEncoding];
 }
@@ -37,9 +37,9 @@ RCT_EXPORT_MODULE()
 - (NSString*) deviceName
 {
     static NSDictionary* deviceNamesByCode = nil;
-    
+
     if (!deviceNamesByCode) {
-        
+
         deviceNamesByCode = @{@"i386"      :@"Simulator",
                               @"x86_64"    :@"Simulator",
                               @"iPod1,1"   :@"iPod Touch",      // (Original)
@@ -100,12 +100,12 @@ RCT_EXPORT_MODULE()
                               @"AppleTV5,3":@"Apple TV",        // Apple TV (4th Generation)
                               };
     }
-    
+
     NSString* deviceName = [deviceNamesByCode objectForKey:self.deviceId];
-    
+
     if (!deviceName) {
         // Not found on database. At least guess main device type from string contents:
-        
+
         if ([self.deviceId rangeOfString:@"iPod"].location != NSNotFound) {
             deviceName = @"iPod Touch";
         }
@@ -132,6 +132,12 @@ RCT_EXPORT_MODULE()
     return language;
 }
 
+- (NSString*) deviceCountry
+{
+  NSString *country = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
+  return country;
+}
+
 - (NSDictionary *)constantsToExport
 {
     UIDevice *currentDevice = [UIDevice currentDevice];
@@ -146,6 +152,7 @@ RCT_EXPORT_MODULE()
              @"deviceId": self.deviceId,
              @"deviceName": currentDevice.name,
              @"deviceLocale": self.deviceLocale,
+             @"deviceCountry": self.deviceCountry,
              @"uniqueId": uniqueId,
              @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
              @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
@@ -156,4 +163,3 @@ RCT_EXPORT_MODULE()
 }
 
 @end
-

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -79,6 +79,7 @@ RCT_EXPORT_MODULE()
                               @"iPhone7,2" :@"iPhone 6",        //
                               @"iPhone8,1" :@"iPhone 6s",       //
                               @"iPhone8,2" :@"iPhone 6s Plus",  //
+                              @"iPhone8,4" :@"iPhone SE",       //
                               @"iPad4,1"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Wifi
                               @"iPad4,2"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Cellular
                               @"iPad4,3"   :@"iPad Air",        // 5th Generation iPad (iPad Air)
@@ -92,8 +93,10 @@ RCT_EXPORT_MODULE()
                               @"iPad5,2"   :@"iPad Mini 4",     // (4th Generation iPad Mini)
                               @"iPad5,3"   :@"iPad Air 2",      // 6th Generation iPad (iPad Air 2)
                               @"iPad5,4"   :@"iPad Air 2",      // 6th Generation iPad (iPad Air 2)
-                              @"iPad6,7"   :@"iPad Pro",        // iPad Pro
-                              @"iPad6,8"   :@"iPad Pro",        // iPad Pro
+                              @"iPad6,3"   :@"iPad Pro 9.7-inch",// iPad Pro 9.7-inch
+                              @"iPad6,4"   :@"iPad Pro 9.7-inch",// iPad Pro 9.7-inch
+                              @"iPad6,7"   :@"iPad Pro 12.9-inch",// iPad Pro 12.9-inch
+                              @"iPad6,8"   :@"iPad Pro 12.9-inch",// iPad Pro 12.9-inch
                               @"AppleTV2,1":@"Apple TV",        // Apple TV (2nd Generation)
                               @"AppleTV3,1":@"Apple TV",        // Apple TV (3rd Generation)
                               @"AppleTV3,2":@"Apple TV",        // Apple TV (3rd Generation - Rev A)

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -77,8 +77,8 @@ RCT_EXPORT_MODULE()
                               @"iPhone6,2" :@"iPhone 5s",       // (model A1457, A1518, A1528 (China), A1530 | Global)
                               @"iPhone7,1" :@"iPhone 6 Plus",   //
                               @"iPhone7,2" :@"iPhone 6",        //
-                              @"iPhone8,1" :@"iPhone 6S",       //
-                              @"iPhone8,2" :@"iPhone 6S Plus",  //
+                              @"iPhone8,1" :@"iPhone 6s",       //
+                              @"iPhone8,2" :@"iPhone 6s Plus",  //
                               @"iPad4,1"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Wifi
                               @"iPad4,2"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Cellular
                               @"iPad4,3"   :@"iPad Air",        // 5th Generation iPad (iPad Air)

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -160,6 +160,7 @@ RCT_EXPORT_MODULE()
              @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
              @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
              @"buildNumber": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
+             @"buildVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleBuildVersion"],
              @"systemManufacturer": @"Apple",
              @"userAgent": self.userAgent,
              };

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -160,7 +160,6 @@ RCT_EXPORT_MODULE()
              @"bundleId": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
              @"appVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
              @"buildNumber": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
-             @"buildVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleBuildVersion"],
              @"systemManufacturer": @"Apple",
              @"userAgent": self.userAgent,
              };

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -44,6 +44,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
   }
 
+  private String getCurrentCountry() {
+    Locale current = getReactApplicationContext().getResources().getConfiguration().locale;
+    return current.getCountry();
+  }
+
   @Override
   public @Nullable Map<String, Object> getConstants() {
     HashMap<String, Object> constants = new HashMap<String, Object>();
@@ -77,6 +82,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("model", Build.MODEL);
     constants.put("deviceId", Build.BOARD);
     constants.put("deviceLocale", this.getCurrentLanguage());
+    constants.put("deviceCountry", this.getCurrentCountry());
     constants.put("uniqueId", Secure.getString(this.reactContext.getContentResolver(), Secure.ANDROID_ID));
     constants.put("systemManufacturer", Build.MANUFACTURER);
     constants.put("bundleId", packageName);

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -57,6 +57,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     String packageName = this.reactContext.getPackageName();
 
     constants.put("appVersion", "not available");
+    constants.put("buildVersion", "not available");
     constants.put("buildNumber", 0);
 
     try {

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -85,6 +85,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("deviceLocale", this.getCurrentLanguage());
     constants.put("deviceCountry", this.getCurrentCountry());
     constants.put("uniqueId", Secure.getString(this.reactContext.getContentResolver(), Secure.ANDROID_ID));
+    System.out.println("content resolver:" + this.reactContext.getContentResolver());
+    System.out.println("android id:" + Secure.getString(this.reactContext.getContentResolver(), Secure.ANDROID_ID));
     constants.put("systemManufacturer", Build.MANUFACTURER);
     constants.put("bundleId", packageName);
     constants.put("userAgent", System.getProperty("http.agent"));

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -43,5 +43,8 @@ module.exports = {
   },
   getDeviceLocale: function() {
     return RNDeviceInfo.deviceLocale;
-  }
+  },
+  getDeviceCountry: function() {
+    return RNDeviceInfo.deviceCountry;
+  },
 };

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -29,6 +29,9 @@ module.exports = {
   getBuildNumber: function() {
     return RNDeviceInfo.buildNumber;
   },
+  getBuildVersion: function() {
+    return RNDeviceInfo.buildVersion;
+  },
   getVersion: function() {
     return RNDeviceInfo.appVersion;
   },

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -29,9 +29,6 @@ module.exports = {
   getBuildNumber: function() {
     return RNDeviceInfo.buildNumber;
   },
-  getBuildVersion: function() {
-    return RNDeviceInfo.buildVersion;
-  },
   getVersion: function() {
     return RNDeviceInfo.appVersion;
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Get device information using react-native",
   "main": "deviceinfo.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Get device information using react-native",
   "main": "deviceinfo.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Get device information using react-native",
   "main": "deviceinfo.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Get device information using react-native",
   "main": "deviceinfo.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-info",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Get device information using react-native",
   "main": "deviceinfo.js",
   "repository": {


### PR DESCRIPTION
Adding support for Android's Instance ID - https://developers.google.com/instance-id/

... implemented b/c needed a replacement due to getUniqueID not working on android (and is Google's best practice recommendation for identifying an instance an app on a device)