### PR TITLE
device name issue on emulator

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -68,14 +68,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       e.printStackTrace();
     }
 
-    String deviceName = "Unknown";
-
-    try {
-      BluetoothAdapter myDevice = BluetoothAdapter.getDefaultAdapter();
-      deviceName = myDevice.getName();
-    } catch(Exception e) {
-      e.printStackTrace();
-    }
+    String deviceName = Build.MANUFACTURER + " " + Build.MODEL
 
     constants.put("deviceName", deviceName);
     constants.put("systemName", "Android");


### PR DESCRIPTION
BluetoothAdapter does not work well on emulator. for simplicity we can make use of MANUFACTURER and MODEL.

Best thing can be to make use of https://github.com/jaredrummler/AndroidDeviceNames

Here is reference discussion on stackoverflow http://stackoverflow.com/questions/7071281/get-android-device-name