### PR TITLE
Update com.google.android.gms:play-services-gcm to 9+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.11.+'
-    compile 'com.google.android.gms:play-services-gcm:8.3.0'
+    compile 'com.google.android.gms:play-services-gcm:9.+'
 }


### PR DESCRIPTION
Updating this library to 9+ versions helped me to get rid of these errors:

duplicate entry: com/google/android/gms/iid/MessengerCompat$1.class
or
duplicate entry: android/support/v7/appcompat/R$anim.class
