### PR TITLE
added getIsTablet method to detect iPad or Android Tablet screen sizes

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -25,6 +25,11 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
+- (BOOL) isTablet
+{
+    return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
+}
+
 - (NSString*) deviceId
 {
     struct utsname systemInfo;
@@ -160,6 +165,7 @@ RCT_EXPORT_MODULE()
              @"systemVersion": currentDevice.systemVersion,
              @"model": self.deviceName,
              @"brand": @"Apple",
+             @"isTablet": @(self.isTablet),
              @"deviceId": self.deviceId,
              @"deviceName": currentDevice.name,
              @"deviceLocale": self.deviceLocale,

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -3,6 +3,7 @@ package com.learnium.RNDeviceInfo;
 import android.bluetooth.BluetoothAdapter;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.os.Build;
 import android.provider.Settings.Secure;
 
@@ -52,6 +53,12 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     return current.getCountry();
   }
 
+  private boolean getIsTablet() {
+    int layout = getReactApplicationContext().getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK;
+
+    return (layout == Configuration.SCREENLAYOUT_SIZE_LARGE || layout == Configuration.SCREENLAYOUT_SIZE_XLARGE);
+  }
+
   @Override
   public @Nullable Map<String, Object> getConstants() {
     HashMap<String, Object> constants = new HashMap<String, Object>();
@@ -81,6 +88,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     }
 
     constants.put("instanceId", InstanceID.getInstance(this.reactContext).getId());
+    constants.put("isTablet",this.getIsTablet());
     constants.put("deviceName", deviceName);
     constants.put("systemName", "Android");
     constants.put("systemVersion", Build.VERSION.RELEASE);

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -11,6 +11,9 @@ module.exports = {
   getInstanceID: function() {
     return RNDeviceInfo.instanceId;
   },
+  getIsTablet: function () {
+    return RNDeviceInfo.isTablet;
+  },
   getDeviceId: function () {
     return RNDeviceInfo.deviceId;
   },
@@ -52,8 +55,5 @@ module.exports = {
   },
   getDeviceCountry: function() {
     return RNDeviceInfo.deviceCountry;
-  },
-  getTimezone: function() {
-    return RNDeviceInfo.timezone;
   },
 };


### PR DESCRIPTION
Handy method so you can switch layouts or styles for Tablets. Blatantly based on the Appcelerator Titanium / Alloy isTablet property code.
