### PR TITLE
Update iOS RN header paths

### DIFF
--- a/RNDeviceInfo.xcodeproj/project.pbxproj
+++ b/RNDeviceInfo.xcodeproj/project.pbxproj
@@ -217,11 +217,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../../React/**",
 					"$(inherited)",
-					"$(SRCROOT)/node_modules/react-native/React/**",
-					"$(SRCROOT)/../react-native/React/**",
-					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -234,11 +231,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../../React/**",
 					"$(inherited)",
-					"$(SRCROOT)/node_modules/react-native/React/**",
-					"$(SRCROOT)/../react-native/React/**",
-					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";

--- a/RNDeviceInfo/RNDeviceInfo.h
+++ b/RNDeviceInfo/RNDeviceInfo.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 #import <sys/utsname.h>
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNDeviceInfo : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/e1577df1fd70049ce7f288f91f6e2b18d512ff4d moves header imports to `<React/*>`. This updates header include path and all imports so build works against react master (soon to be version 0.40.0).