### PR TITLE
[FEATURE] get emulated device while running simulator

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -111,6 +111,13 @@ RCT_EXPORT_MODULE()
 
     NSString* deviceName = [deviceNamesByCode objectForKey:self.deviceId];
 
+    if ([deviceName isEqual: @"Simulator"]) {
+      // prefer device name
+      if ([[[NSProcessInfo processInfo] environment] objectForKey:@"SIMULATOR_MODEL_IDENTIFIER"]) {
+        deviceName = [deviceNamesByCode objectForKey:[[[NSProcessInfo processInfo] environment] objectForKey:@"SIMULATOR_MODEL_IDENTIFIER"]];
+      }
+    }
+
     if (!deviceName) {
         // Not found on database. At least guess main device type from string contents:
 
@@ -154,7 +161,16 @@ RCT_EXPORT_MODULE()
 
 - (bool) isEmulator
 {
-  return [self.deviceName isEqual: @"Simulator"];
+  static NSDictionary* deviceNamesByCode = nil;
+
+  if (!deviceNamesByCode) {
+      deviceNamesByCode = @{@"i386"      :@"Simulator",
+                            @"x86_64"    :@"Simulator"
+                          };
+  }
+
+  NSString* deviceName = [deviceNamesByCode objectForKey:self.deviceId];
+  return [deviceName isEqual: @"Simulator"];
 }
 
 - (bool) isTablet


### PR DESCRIPTION
I wanted to fix https://github.com/rebeccahughes/react-native-device-info/issues/104 so made a change to check the environment variables to see what the simulated device should be.

In my opinion the deviceName call should return the simulated deviceName and not 'Simulator'. Detecting if it's a simulator requires a secondary call to isEmulator() (which I'd prefer be called isSimulator(), but that's something else.)

Unfortunately I haven't been able to test it out. I'm new to the react-native / xcode interaction and can't seem to get the header search paths right. It returns 'React/RCTBridgeModule.h' file not found, despite having setup $(SRCROOT)/../react-native/React etc.

As I'm out of time at the moment, I thought I'd submit this in case it's useful to someone. 
