### PR TITLE
Update RNDeviceModule.java

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -92,7 +92,9 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
     try {
       BluetoothAdapter myDevice = BluetoothAdapter.getDefaultAdapter();
-      deviceName = myDevice.getName();
+      if(mDevice!=null){
+        deviceName = myDevice.getName();
+      }
     } catch(Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
There might be some scenario where the developers who are using this library might not be using Bluetooth permission. so this mDevice object will be null in this case and it should be handled properly. As some will not want to add this unnecessary permission in their project.