### PR TITLE
Remove deprecated `createJSModules`

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceInfo.java
@@ -24,11 +24,6 @@ public class RNDeviceInfo implements ReactPackage {
   }
 
   @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-  	return Collections.emptyList();
-  }
-
-  @Override
   public List<ViewManager> createViewManagers(
                             ReactApplicationContext reactContext) {
   	return Collections.emptyList();


### PR DESCRIPTION
Since react-native 0.47