### PR TITLE
fix(Types): TS type definitions didn't use the correct export mechanism

### DIFF
--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -1,27 +1,23 @@
 // should be imported this way: 
-// import DeviceInfo from 'react-native-device-info';
+// import * as DeviceInfo from 'react-native-device-info';
 
-declare class DeviceInfo {
-  public static getUniqueID(): string;
-  public static getManufacturer(): string;
-  public static getBrand(): string;
-  public static getModel(): string;
-  public static getDeviceId(): string;
-  public static getSystemName(): string;
-  public static getSystemVersion(): string;
-  public static getBundleId(): string;
-  public static getBuildNumber(): string;
-  public static getVersion(): string;
-  public static getReadableVersion(): string;
-  public static getDeviceName(): string;
-  public static getUserAgent(): string;
-  public static getDeviceLocale(): string;
-  public static getDeviceCountry(): string;
-  public static getTimezone(): string;
-  public static getInstanceID(): string;
-  public static isEmulator(): boolean;
-  public static isTablet(): boolean;
-  public static isPinOrFingerprintSet(): (cb: (isPinOrFingerprintSet: boolean) => void) => void;
-}
-
-export default DeviceInfo;
+export function getUniqueID(): string;
+export function getManufacturer(): string;
+export function getBrand(): string;
+export function getModel(): string;
+export function getDeviceId(): string;
+export function getSystemName(): string;
+export function getSystemVersion(): string;
+export function getBundleId(): string;
+export function getBuildNumber(): string;
+export function getVersion(): string;
+export function getReadableVersion(): string;
+export function getDeviceName(): string;
+export function getUserAgent(): string;
+export function getDeviceLocale(): string;
+export function getDeviceCountry(): string;
+export function getTimezone(): string;
+export function getInstanceID(): string;
+export function isEmulator(): boolean;
+export function isTablet(): boolean;
+export function isPinOrFingerprintSet(): (cb: (isPinOrFingerprintSet: boolean) => void) => void;


### PR DESCRIPTION
Reverting #12c93cb that has broken TS support.

based on @aarondail's issue: 
https://github.com/rebeccahughes/react-native-device-info/issues/208

We've bumped into the same problem.