### PR TITLE
Add support for new iPhone, iPad, and Apple TV models

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -95,9 +95,12 @@ RCT_EXPORT_MODULE()
                               @"iPhone9,3" :@"iPhone 7",        // (model A1778 | Global)
                               @"iPhone9,2" :@"iPhone 7 Plus",   // (model A1661 | CDMA)
                               @"iPhone9,4" :@"iPhone 7 Plus",   // (model A1784 | Global)
-                              @"iPhone10,3":@"iPhone X",        //
-                              @"iPhone10,4":@"iPhone 8",        //
-                              @"iPhone10,5":@"iPhone 8 Plus",   //
+                              @"iPhone10,3":@"iPhone X",        // (model A1865, A1902)
+                              @"iPhone10,6":@"iPhone X",        // (model A1901)
+                              @"iPhone10,1":@"iPhone 8",        // (model A1863, A1906, A1907)
+                              @"iPhone10,4":@"iPhone 8",        // (model A1905)
+                              @"iPhone10,2":@"iPhone 8 Plus",   // (model A1864, A1898, A1899)
+                              @"iPhone10,5":@"iPhone 8 Plus",   // (model A1897)
                               @"iPad4,1"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Wifi
                               @"iPad4,2"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Cellular
                               @"iPad4,3"   :@"iPad Air",        // 5th Generation iPad (iPad Air)
@@ -115,10 +118,15 @@ RCT_EXPORT_MODULE()
                               @"iPad6,4"   :@"iPad Pro 9.7-inch",// iPad Pro 9.7-inch
                               @"iPad6,7"   :@"iPad Pro 12.9-inch",// iPad Pro 12.9-inch
                               @"iPad6,8"   :@"iPad Pro 12.9-inch",// iPad Pro 12.9-inch
+                              @"iPad7,1"   :@"iPad Pro 12.9-inch",// 2nd Generation iPad Pro 12.5-inch - Wifi
+                              @"iPad7,2"   :@"iPad Pro 12.9-inch",// 2nd Generation iPad Pro 12.5-inch - Cellular
+                              @"iPad7,3"   :@"iPad Pro 10.5-inch",// iPad Pro 12.5-inch - Wifi
+                              @"iPad7,4"   :@"iPad Pro 10.5-inch",// iPad Pro 12.5-inch - Cellular
                               @"AppleTV2,1":@"Apple TV",        // Apple TV (2nd Generation)
                               @"AppleTV3,1":@"Apple TV",        // Apple TV (3rd Generation)
                               @"AppleTV3,2":@"Apple TV",        // Apple TV (3rd Generation - Rev A)
                               @"AppleTV5,3":@"Apple TV",        // Apple TV (4th Generation)
+                              @"AppleTV6,2":@"Apple TV 4K",     // Apple TV 4K
                               };
     }
 


### PR DESCRIPTION
Now supports iPad Pro 10.5-inch, 2nd Generation iPad Pro 12.5-inch, Apple TV 4K, and additional models of iPhone 8, 8s and X.