### PR TITLE
Fix RN 0.48+ warning about requiresMainQueueSetup

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -15,18 +15,16 @@
 @end
 
 @implementation RNDeviceInfo
-{
-
-}
 
 @synthesize isEmulator;
 
 RCT_EXPORT_MODULE()
-
-- (dispatch_queue_t)methodQueue
+    
++ (BOOL)requiresMainQueueSetup
 {
-    return dispatch_get_main_queue();
+   return YES;
 }
+
 
 - (NSString*) deviceId
 {


### PR DESCRIPTION
Warning: Module RNDeviceInfo requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.