### PR TITLE
Fix "Neither user nor current process has android.persmission.ACCESS_WIFI_STATE"

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -40,15 +40,19 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     super(reactContext);
 
     this.reactContext = reactContext;
-
-
-    WifiManager manager = (WifiManager) reactContext.getSystemService(Context.WIFI_SERVICE);
-    this.wifiInfo = manager.getConnectionInfo();
   }
 
   @Override
   public String getName() {
     return "RNDeviceInfo";
+  }
+
+  private WifiInfo getWifiInfo() {
+    if ( this.wifiInfo == null ) {
+      WifiManager manager = (WifiManager) reactContext.getSystemService(Context.WIFI_SERVICE);
+      this.wifiInfo = manager.getConnectionInfo();
+    }
+    return this.wifiInfo;
   }
 
   private String getCurrentLanguage() {
@@ -95,13 +99,13 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getIpAddress(Promise p) {
-    String ipAddress = Formatter.formatIpAddress(wifiInfo.getIpAddress());
+    String ipAddress = Formatter.formatIpAddress(getWifiInfo().getIpAddress());
     p.resolve(ipAddress);
   }
 
   @ReactMethod
   public void getMacAddress(Promise p) {
-    String macAddress = wifiInfo.getMacAddress();
+    String macAddress = getWifiInfo().getMacAddress();
     p.resolve(macAddress);
   }
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -49,7 +49,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
   private WifiInfo getWifiInfo() {
     if ( this.wifiInfo == null ) {
-      WifiManager manager = (WifiManager) reactContext.getSystemService(Context.WIFI_SERVICE);
+      WifiManager manager = (WifiManager) reactContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
       this.wifiInfo = manager.getConnectionInfo();
     }
     return this.wifiInfo;
@@ -93,7 +93,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void isPinOrFingerprintSet(Callback callback) {
-    KeyguardManager keyguardManager = (KeyguardManager) this.reactContext.getSystemService(Context.KEYGUARD_SERVICE); //api 16+
+    KeyguardManager keyguardManager = (KeyguardManager) this.reactContext.getApplicationContext().getSystemService(Context.KEYGUARD_SERVICE); //api 16+
     callback.invoke(keyguardManager.isKeyguardSecure());
   }
 
@@ -165,7 +165,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
           (getCurrentActivity().checkCallingOrSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED ||
             getCurrentActivity().checkCallingOrSelfPermission(Manifest.permission.READ_SMS) == PackageManager.PERMISSION_GRANTED ||
             getCurrentActivity().checkCallingOrSelfPermission("android.permission.READ_PHONE_NUMBERS") == PackageManager.PERMISSION_GRANTED)) {
-        TelephonyManager telMgr = (TelephonyManager) this.reactContext.getSystemService(Context.TELEPHONY_SERVICE);
+        TelephonyManager telMgr = (TelephonyManager) this.reactContext.getApplicationContext().getSystemService(Context.TELEPHONY_SERVICE);
         constants.put("phoneNumber", telMgr.getLine1Number());
     }
     return constants;


### PR DESCRIPTION
[Android][bug] Neither user nor current process has android.persmission.ACCESS_WIFI_STATE

Hello!
After update from 0.11.0 to 0.12.0 it crashes on install

This PR not force people to add wifi permission and leave 2 new methods "getIP" and "getMac" only to folks who need it.