### PR TITLE
Fixing `@synthesize isEmulator` duplicate

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -18,8 +18,6 @@
 
 @synthesize isEmulator;
 
-@synthesize isEmulator;
-
 RCT_EXPORT_MODULE()
     
 + (BOOL)requiresMainQueueSetup


### PR DESCRIPTION
Fixes bug introduced in #226.