### PR TITLE
Add fallback when webview is not installed

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -170,7 +170,11 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("systemManufacturer", Build.MANUFACTURER);
     constants.put("bundleId", packageName);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      constants.put("userAgent", WebSettings.getDefaultUserAgent(this.reactContext));
+      try {
+        constants.put("userAgent", WebSettings.getDefaultUserAgent(this.reactContext));
+      } catch (PackageManager.NameNotFoundException e) {
+        constants.put("userAgent", System.getProperty("http.agent"));
+      }
     }
     constants.put("timezone", TimeZone.getDefault().getID());
     constants.put("isEmulator", this.isEmulator());


### PR DESCRIPTION
Fixes #272 

Stack trace for crash:

```
Java exception in 'NativeModules' android.util.AndroidRuntimeException: 
android.content.pm.PackageManager$NameNotFoundException: com.google.android.webview, 
stack: 
android.webkit.WebViewFactory.getFactoryClass@174 
android.webkit.WebViewFactory.getProvider@109 
android.webkit.WebSettings.getDefaultUserAgent@1229
```