### PR TITLE
Fix export module name

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -22,7 +22,7 @@
 
 @synthesize isEmulator;
 
-RCT_EXPORT_MODULE()
+RCT_EXPORT_MODULE(RNDeviceInfo)
 
 + (BOOL)requiresMainQueueSetup
 {


### PR DESCRIPTION
The name of the native module export on IOS sometimes differ from the one used in the JS code, specifying the name of the module fix the problem

Fix #236 
