### PR TITLE
Catch right exception on RNDeviceModule

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -172,7 +172,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
       try {
         constants.put("userAgent", WebSettings.getDefaultUserAgent(this.reactContext));
-      } catch (PackageManager.NameNotFoundException e) {
+      } catch (RuntimeException e) {
         constants.put("userAgent", System.getProperty("http.agent"));
       }
     }


### PR DESCRIPTION
`error: exception NameNotFoundException is never thrown in body of corresponding try statement`

This error happen during compile due to WebSettings.getDefaultUserAgent throw `RunTimeException` instead of `PackageManager.NameNotFoundException`
This fix would catch the right exception