### PR TITLE
fix: make getTotalDiskCapacity() and getFreeDiskStorage() available < SDK18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Next
 
+### 0.15.1
+
+* Fix Android compatibility for `getFreeDiskStorage` and `getTotalDiskCapacity` (https://github.com/rebeccahughes/react-native-device-info/pull/319)
+
 ### 0.15.0
 
 * Add `getFontScale` (https://github.com/rebeccahughes/react-native-device-info/pull/278)

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -127,15 +127,15 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public long getTotalDiskCapacity() {
+  public int getTotalDiskCapacity() {
     StatFs root = new StatFs(Environment.getRootDirectory().getAbsolutePath());
-    return root.getBlockCountLong() * root.getBlockSizeLong();
+    return root.getBlockCount() * root.getBlockSize();
   }
 
   @ReactMethod
-  public long getFreeDiskStorage() {
+  public int getFreeDiskStorage() {
     StatFs external = new StatFs(Environment.getExternalStorageDirectory().getAbsolutePath());
-    return external.getAvailableBlocksLong() * external.getBlockSizeLong();
+    return external.getAvailableBlocks() * external.getBlockSize();
   }
 
   @Override


### PR DESCRIPTION
## Description

Fixed issue #318 by using Android methods available since API Level 1

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
