### PR TITLE
feat: Google play services versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### next
 
+* Add Gradle build config that allows a consumer to set Play Services Version from a root-project ext variable.
+
 ### 0.15.3
 
 * Fix crash on iOS: prevent insertion of nil values in the dictionary (https://github.com/rebeccahughes/react-native-device-info/pull/328)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ Run your project (Cmd+R)
 <details>
     <summary>Android</summary>
 
+* **_optional_** in `android/build.gradle`:
+
+```gradle
+...
+  ext {
+    // dependency versions
+    googlePlayServicesVersion = "<Your Services Version>"
+  }
+...
+```
+
 * in `android/app/build.gradle`:
 
 ```diff

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,8 @@ android {
 }
 
 dependencies {
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "+"
+
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:+'
+    compile "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
## Description

Added a new Gradle build config that pulls the root-project ext variable  `googlePlayServicesVersion` if it exists and sets the module's play-services-gcm version. It defaults to `+` if it doesn't exist mimicking the current functionality. 

## Compatibility

Gradle Build Configuration

| Android |    ✅     |


## Checklist

<!-- Check completed item: [X] -->

* ✅ I have tested this on a device/simulator for each compatible OS
* ✅ I added the documentation in `README.md`.
* ✅ I mentioned this change in `CHANGELOG.md`.