### PR TITLE
Removes getInstanceID and Google Play Services dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### next
 
+* Removes `getInstanceID` and Google Play Services dependency (https://github.com/rebeccahughes/react-native-device-info/pull/334)
+
 ### 0.15.3
 
 * Fix crash on iOS: prevent insertion of nil values in the dictionary (https://github.com/rebeccahughes/react-native-device-info/pull/328)

--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ var DeviceInfo = require('react-native-device-info');
 | [getFontScale()](#getfontscale)                   | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
 | [getFreeDiskStorage()](#getfreediskstorage)       | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
 | [getIPAddress()](#getipaddress)                   | `Promise<string>`   |  ❌  |   ✅    |   ❌    | 0.12.0 |
-| [getInstanceID()](#getinstanceid)                 | `string`            |  ❌  |   ✅    |   ❌    | ?      |
 | [getLastUpdateTime()](#getlastupdatetime)         | `number`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getMACAddress()](#getmacaddress)                 | `Promise<string>`   |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getManufacturer()](#getmanufacturer)             | `string`            |  ✅  |   ✅    |   ✅    | ?      |
@@ -440,24 +439,6 @@ DeviceInfo.getIPAddress().then(ip => {
 **Android Permissions**
 
 * [android.permission.ACCESS_WIFI_STATE](https://developer.android.com/reference/android/Manifest.permission.html#ACCESS_WIFI_STATE)
-
----
-
-### getInstanceID()
-
-Gets the application instance ID.
-
-**Examples**
-
-```js
-const instanceId = DeviceInfo.getInstanceID();
-
-// Android: ?
-```
-
-**Notes**
-
-> See https://developers.google.com/instance-id/
 
 ---
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,5 +20,4 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:+'
 }

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -190,13 +190,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     }
 
 
-    try {
-      if (Class.forName("com.google.android.gms.iid.InstanceID") != null) {
-        constants.put("instanceId", com.google.android.gms.iid.InstanceID.getInstance(this.reactContext).getId());
-      }
-    } catch (ClassNotFoundException e) {
-      constants.put("instanceId", "N/A: Add com.google.android.gms:play-services-gcm to your project.");
-    }
     constants.put("serialNumber", Build.SERIAL);
     constants.put("deviceName", deviceName);
     constants.put("systemName", "Android");

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -18,7 +18,6 @@ export function getUserAgent(): string;
 export function getDeviceLocale(): string;
 export function getDeviceCountry(): string;
 export function getTimezone(): string;
-export function getInstanceID(): string;
 export function isEmulator(): boolean;
 export function isTablet(): boolean;
 export function getFontScale(): number;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -8,9 +8,6 @@ module.exports = {
   getUniqueID: function() {
     return RNDeviceInfo.uniqueId;
   },
-  getInstanceID: function() {
-    return RNDeviceInfo.instanceId;
-  },
   getSerialNumber: function() {
     return RNDeviceInfo.serialNumber;
   },

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -18,7 +18,6 @@ declare module.exports: {
   getDeviceLocale: () => string,
   getDeviceCountry: () => string,
   getTimezone: () => string,
-  getInstanceID: () => string,
   isEmulator: () => boolean,
   isTablet: () => boolean,
   getFontScale: () => number,

--- a/windows/RNDeviceInfo/RNDeviceInfoModule.cs
+++ b/windows/RNDeviceInfo/RNDeviceInfoModule.cs
@@ -100,7 +100,6 @@ namespace RNDeviceInfo
                 {
                 }
                 
-                constants["instanceId"] = "not available";
                 constants["deviceName"] = deviceName;
                 constants["systemName"] = "Windows";
                 constants["systemVersion"] = osVersion;


### PR DESCRIPTION
## Description

Removes `getInstanceID()` which allows for removal of Google Play Services dependency. There are [numerous open issues](https://github.com/rebeccahughes/react-native-device-info/search?q=gcm&type=Issues&utf8=%E2%9C%93) related to versioning conflicts or missing/failed dependency resolution for, IMHO, marginal utility gained from this requirement. The change in https://github.com/rebeccahughes/react-native-device-info/pull/226 to make this dependency optional doesn't alleviate versioning conflicts if another dependency (like https://github.com/zo0r/react-native-push-notification) requires `play-services-gcm`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |
| Windows |    ✅    |

## Checklist

* [ ] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`.
* [x] I mentionned this change in `CHANGELOG.md`.
