### PR TITLE
feat: add getInstallReferrer() for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ var DeviceInfo = require('react-native-device-info');
 | [getFontScale()](#getfontscale)                   | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
 | [getFreeDiskStorage()](#getfreediskstorage)       | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
 | [getIPAddress()](#getipaddress)                   | `Promise<string>`   |  ❌  |   ✅    |   ❌    | 0.12.0 |
-| [getInstallReferrer()](#getinstallreferrer)       | `string`            |  ❌  |   ✅    |   ❌    | ?      |
+| [getInstallReferrer()](#getinstallreferrer)       | `string`            |  ❌  |   ✅    |   ❌    | 0.19.0 |
 | [getInstanceID()](#getinstanceid)                 | `string`            |  ❌  |   ✅    |   ❌    | ?      |
 | [getLastUpdateTime()](#getlastupdatetime)         | `number`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getMACAddress()](#getmacaddress)                 | `Promise<string>`   |  ❌  |   ✅    |   ❌    | 0.12.0 |
@@ -483,14 +483,15 @@ DeviceInfo.getIPAddress().then(ip => {
 
 ### getInstallReferrer
 
-Gets the referrer string upon application installation.
+Gets the referrer string upon application installation. 
 
 **Examples**
 
 ```js
 const referrer = DeviceInfo.getInstallReferrer();
 
-// Android: my_install_referrer
+// If the app was installed from https://play.google.com/store/apps/details?id=com.myapp&referrer=my_install_referrer
+// the result will be "my_install_referrer"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ var DeviceInfo = require('react-native-device-info');
 | [getFontScale()](#getfontscale)                   | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
 | [getFreeDiskStorage()](#getfreediskstorage)       | `number`            |  ✅  |   ✅    |   ❌    | 0.15.0 |
 | [getIPAddress()](#getipaddress)                   | `Promise<string>`   |  ❌  |   ✅    |   ❌    | 0.12.0 |
+| [getInstallReferrer()](#getinstallreferrer)       | `string`            |  ❌  |   ✅    |   ❌    | ?      |
 | [getInstanceID()](#getinstanceid)                 | `string`            |  ❌  |   ✅    |   ❌    | ?      |
 | [getLastUpdateTime()](#getlastupdatetime)         | `number`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getMACAddress()](#getmacaddress)                 | `Promise<string>`   |  ❌  |   ✅    |   ❌    | 0.12.0 |
@@ -461,6 +462,20 @@ DeviceInfo.getIPAddress().then(ip => {
 **Android Permissions**
 
 * [android.permission.ACCESS_WIFI_STATE](https://developer.android.com/reference/android/Manifest.permission.html#ACCESS_WIFI_STATE)
+
+---
+
+### getInstallReferrer
+
+Gets the referrer string upon application installation.
+
+**Examples**
+
+```js
+const referrer = DeviceInfo.getInstallReferrer();
+
+// Android: my_install_referrer
+```
 
 ---
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.learnium.RNDeviceInfo">
           
+    <application>
+        <receiver
+            android:name="com.learnium.RNDeviceInfo.RNDeviceReceiver"
+            android:enabled="true"
+            android:exported="true"
+        >
+            <intent-filter>
+                <action android:name="com.android.vending.INSTALL_REFERRER" />
+            </intent-filter>
+        </receiver>
+    </application>
 
 </manifest>

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.app.KeyguardManager;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -161,6 +162,12 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     return null;
   }
 
+  @ReactMethod
+  public String getInstallReferrer() {
+    SharedPreferences sharedPref = getReactApplicationContext().getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
+    return sharedPref.getString("installReferrer", null);
+  }
+
   @Override
   public @Nullable
   Map<String, Object> getConstants() {
@@ -245,6 +252,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     constants.put("carrier", this.getCarrier());
     constants.put("totalDiskCapacity", this.getTotalDiskCapacity());
     constants.put("freeDiskStorage", this.getFreeDiskStorage());
+    constants.put("installReferrer", this.getInstallReferrer());
 
     Runtime rt = Runtime.getRuntime();
     constants.put("maxMemory", rt.maxMemory());

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
@@ -1,0 +1,21 @@
+package com.learnium.RNDeviceInfo;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class RNDeviceReceiver extends BroadcastReceiver {
+  private static String installReferrer = "";
+
+  public static String getInstallReferrer() {
+    return installReferrer;
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    String action = intent.getAction();
+    if (action.equals("com.android.vending.INSTALL_REFERRER")) {
+      installReferrer = intent.getStringExtra("referrer");
+    }
+  }
+}

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceReceiver.java
@@ -3,19 +3,18 @@ package com.learnium.RNDeviceInfo;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
 
 public class RNDeviceReceiver extends BroadcastReceiver {
-  private static String installReferrer = "";
-
-  public static String getInstallReferrer() {
-    return installReferrer;
-  }
-
   @Override
   public void onReceive(Context context, Intent intent) {
     String action = intent.getAction();
     if (action.equals("com.android.vending.INSTALL_REFERRER")) {
-      installReferrer = intent.getStringExtra("referrer");
+      SharedPreferences sharedPref = context.getSharedPreferences("react-native-device-info", Context.MODE_PRIVATE);
+      SharedPreferences.Editor editor = sharedPref.edit();
+      editor.putString("installReferrer", intent.getStringExtra("referrer"));
+      editor.commit();
     }
   }
 }

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -94,6 +94,9 @@ module.exports = {
   getFirstInstallTime: function() {
     return RNDeviceInfo.firstInstallTime;
   },
+  getInstallReferrer: function() {
+    return RNDeviceInfo.installReferrer;
+  },
   getLastUpdateTime: function() {
     return RNDeviceInfo.lastUpdateTime;
   },

--- a/web/index.js
+++ b/web/index.js
@@ -30,6 +30,7 @@ module.exports = {
   is24Hour: false,
   isPinOrFingerprintSet: callback => callback && callback(false),
   firstInstallTime: 0,
+  installReferrer: '',
   lastUpdateTime: 0,
   phoneNumber: '',
   carrier: '',


### PR DESCRIPTION
## Description

Added `getInstallReferrer()` that returns the install referrer attribution when your android app gets installed (com.android.vending.INSTALL_REFERRER). You can use https://play.google.com/store/apps/details?id=com.myapp&referrer=<your custom referrer string here>

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |   ❌     |
| Android |    ✅    |
| Windows |   ❌     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
