### PR TITLE
Added `getBatteryLevel` for checking the current battery-level of the device

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ var DeviceInfo = require('react-native-device-info');
 | ------------------------------------------------- | ------------------- | :--: | :-----: | :-----: | ------ |
 | [getAPILevel()](#getapilevel)                     | `number`            |  ❌  |   ✅    |   ❌    | 0.12.0 |
 | [getApplicationName()](#getapplicationname)       | `string`            |  ✅  |   ✅    |   ✅    | 0.14.0 |
+| [getBatteryLevel()](#getbatterylevel)             | `Promise<number>`   |  ✅  |   ✅    |   ❌    | 0.18.0 |
 | [getBrand()](#getbrand)                           | `string`            |  ✅  |   ✅    |   ✅    | 0.9.3  |
 | [getBuildNumber()](#getbuildnumber)               | `string`            |  ✅  |   ✅    |   ✅    | ?      |
 | [getBundleId()](#getbundleid)                     | `string`            |  ✅  |   ✅    |   ✅    | ?      |
@@ -261,6 +262,24 @@ Gets the application name.
 ```js
 const appName = DeviceInfo.getApplicationName(); // "Learnium Mobile"
 ```
+
+---
+
+### getBatteryLevel()
+
+Gets the battery level of the device (0..1).
+
+**Examples**
+
+```js
+DeviceInfo.getBatteryLevel().then((batteryLevel) => {
+  // 0.75
+});
+```
+
+**Notes**
+
+> Returns -1 on the iOS Simulator
 
 ---
 

--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -304,4 +304,10 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
     callback(@[[NSNumber numberWithBool:isPinOrFingerprintSet]]);
 }
 
+RCT_EXPORT_METHOD(getBatteryLevel:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    float batteryLevel = device.batteryLevel;
+    resolve(@(batteryLevel));
+}
+
 @end

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -4,6 +4,8 @@ import android.Manifest;
 import android.app.KeyguardManager;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -13,6 +15,7 @@ import android.net.wifi.WifiInfo;
 import android.os.Build;
 import android.os.Environment;
 import android.os.StatFs;
+import android.os.BatteryManager;
 import android.provider.Settings.Secure;
 import android.webkit.WebSettings;
 import android.telephony.TelephonyManager;
@@ -193,6 +196,15 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       e.printStackTrace();
     }
     return null;
+  }
+
+  @ReactMethod
+  public void getBatteryLevel(Promise p) {
+    Intent batteryIntent = this.reactContext.getApplicationContext().registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+    int level = batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
+    int scale = batteryIntent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+    float batteryLevel = level / (float) scale;
+    p.resolve(batteryLevel);
   }
 
   @Override

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -38,3 +38,4 @@ export function getTotalMemory(): number;
 export function getMaxMemory(): number;
 export function getTotalDiskCapacity(): number;
 export function getFreeDiskStorage(): number;
+export function getBatteryLevel(): Promise<number>;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -115,4 +115,7 @@ module.exports = {
   getFreeDiskStorage: function() {
     return RNDeviceInfo.freeDiskStorage;
   },
+  getBatteryLevel: function() {
+    return RNDeviceInfo.getBatteryLevel();
+  },
 };

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -38,4 +38,5 @@ declare module.exports: {
   getMaxMemory: () => number,
   getTotalDiskCapacity: () => number,
   getFreeDiskStorage: () => number,
+  getBatteryLevel: () => Promise<number>,
 };


### PR DESCRIPTION
## Description

Added `getBatteryLevel()` that gets the current device battery level (0..1)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
