### PR TITLE
fix: remove deprecated React pod dependency

### DIFF
--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -13,6 +13,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/rebeccahughes/react-native-device-info.git" }
 
   s.source_files  = "RNDeviceInfo/*.{h,m}"
-
-  s.dependency 'React'
+  
 end


### PR DESCRIPTION
## Description

Fixed issue #352

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`. (Not needed)
* [ ] I mentionned this change in `CHANGELOG.md`.
