### PR TITLE
fix(getBatteryLevel): change method to respect tvos targets

### DIFF
--- a/RNDeviceInfo/RNDeviceInfo.m
+++ b/RNDeviceInfo/RNDeviceInfo.m
@@ -306,7 +306,11 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(getBatteryLevel:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
+  #if TARGET_OS_TV
+    float batteryLevel = 1.0;
+  #else
     float batteryLevel = [UIDevice currentDevice].batteryLevel;
+  #endif
     resolve(@(batteryLevel));
 }
 


### PR DESCRIPTION
## Description

Fixed issue # N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
