### PR TITLE
Return error on appVersion if package not found

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -115,7 +115,6 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     String packageName = this.reactContext.getPackageName();
 
     constants.put("appVersion", "not available");
-    constants.put("buildVersion", "not available");
     constants.put("buildNumber", 0);
 
     try {
@@ -125,6 +124,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       constants.put("firstInstallTime", info.firstInstallTime);
       constants.put("lastUpdateTime", info.lastUpdateTime);
     } catch (PackageManager.NameNotFoundException e) {
+      constants.put("appVersion", "error");
       e.printStackTrace();
     }
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Instead of the default `not-available`, return `error` when a package can not be found (which should not happen). Better for debugging purposes.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
