### PR TITLE
Enabled battery monitoring mode to get actual battery data

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,11 @@ DeviceInfo.getBatteryLevel().then(batteryLevel => {
 
 **Notes**
 
+> To be able to get actual battery level enable battery monitoring mode for application
+add this code:
+  [UIDevice currentDevice].batteryMonitoringEnabled = true;
+to AppDelegate.m application:didFinishLaunchingWithOptions:
 > Returns -1 on the iOS Simulator
-
 ---
 
 ### getBrand()

--- a/README.md
+++ b/README.md
@@ -285,9 +285,10 @@ DeviceInfo.getBatteryLevel().then(batteryLevel => {
 
 > To be able to get actual battery level enable battery monitoring mode for application.
 > Add this code:
->
->    [UIDevice currentDevice].batteryMonitoringEnabled = true;
-> 
+
+```objective-c
+[UIDevice currentDevice].batteryMonitoringEnabled = true;
+```
 > to AppDelegate.m application:didFinishLaunchingWithOptions:
 >
 > Returns -1 on the iOS Simulator

--- a/README.md
+++ b/README.md
@@ -283,10 +283,13 @@ DeviceInfo.getBatteryLevel().then(batteryLevel => {
 
 **Notes**
 
-> To be able to get actual battery level enable battery monitoring mode for application
-add this code:
-  [UIDevice currentDevice].batteryMonitoringEnabled = true;
-to AppDelegate.m application:didFinishLaunchingWithOptions:
+> To be able to get actual battery level enable battery monitoring mode for application.
+> Add this code:
+>
+>    [UIDevice currentDevice].batteryMonitoringEnabled = true;
+> 
+> to AppDelegate.m application:didFinishLaunchingWithOptions:
+>
 > Returns -1 on the iOS Simulator
 ---
 

--- a/ios/RNDeviceInfo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/RNDeviceInfo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -309,8 +309,9 @@ RCT_EXPORT_METHOD(getBatteryLevel:(RCTPromiseResolveBlock)resolve rejecter:(RCTP
   #if TARGET_OS_TV
     float batteryLevel = 1.0;
   #else
-    [UIDevice currentDevice].batteryMonitoringEnabled = true;
-    float batteryLevel = [UIDevice currentDevice].batteryLevel;
+    UIDevice* device = [UIDevice currentDevice];
+    device.batteryMonitoringEnabled = true;
+    float batteryLevel = device.batteryLevel;
   #endif
     resolve(@(batteryLevel));
 }

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -309,6 +309,7 @@ RCT_EXPORT_METHOD(getBatteryLevel:(RCTPromiseResolveBlock)resolve rejecter:(RCTP
   #if TARGET_OS_TV
     float batteryLevel = 1.0;
   #else
+    [UIDevice currentDevice].batteryMonitoringEnabled = true;
     float batteryLevel = [UIDevice currentDevice].batteryLevel;
   #endif
     resolve(@(batteryLevel));

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -309,9 +309,7 @@ RCT_EXPORT_METHOD(getBatteryLevel:(RCTPromiseResolveBlock)resolve rejecter:(RCTP
   #if TARGET_OS_TV
     float batteryLevel = 1.0;
   #else
-    UIDevice* device = [UIDevice currentDevice];
-    device.batteryMonitoringEnabled = true;
-    float batteryLevel = device.batteryLevel;
+    float batteryLevel = [UIDevice currentDevice].batteryLevel;
   #endif
     resolve(@(batteryLevel));
 }


### PR DESCRIPTION
## Description

Fixed issue #396

Enabled battery monitoring mode to get actual battery data

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS
* [x] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.