### PR TITLE
docs: clarify iOS return values of getSystemName

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ Gets the device OS name.
 ```js
 const systemName = DeviceInfo.getSystemName();
 
-// iOS: "iOS"
+// iOS: "iOS" on newer iOS devices "iPhone OS" on older devices, including older iPad's.
 // Android: "Android"
 // Windows: ?
 ```


### PR DESCRIPTION
## Description
This commit will clarify in the README that both "iOS" and "iPhone OS" are possible return values from calling getSystemName when running on an iOS device. "iOS" being reported on most iOS 10+ devices and "iPhone OS" reported on iOS 9 and less and some iOS 10 devices.

Fixed issue #410