### PR TITLE
Export device info

### DIFF
--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -10,6 +10,7 @@ if (!RNDeviceInfo && Platform.OS === 'web') {
 }
 
 module.exports = {
+  data: RNDeviceInfo,
   getUniqueID: function() {
     return RNDeviceInfo.uniqueId;
   },


### PR DESCRIPTION


## Description

<!-- OR, if you're implementing a new feature: -->

All the getters fail if there is no `RNDeviceInfo`. I added an export called `data` that exports the `deviceInfo`.

This way people can do checks like: `deviceInfo.data ? deviceInfo.getUserAgent() : 'default-agent'`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |


