### PR TITLE
RN 0.56+ compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 23
-def DEFAULT_BUILD_TOOLS_VERSION             = "25.0.2"
-def DEFAULT_TARGET_SDK_VERSION              = 22
+def DEFAULT_COMPILE_SDK_VERSION             = 26
+def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.3"
+def DEFAULT_TARGET_SDK_VERSION              = 26
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "+"
 
 android {


### PR DESCRIPTION
## Description

React Native compiles Android project against SDK 26 by default now, https://github.com/facebook/react-native/releases/tag/v0.56.0

Dependencies need to do the same or compilation breaks. This change compiles & runs with RN 0.56

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
