### PR TITLE
Fix android build error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION             = 23
+def DEFAULT_COMPILE_SDK_VERSION             = 24
 def DEFAULT_BUILD_TOOLS_VERSION             = "25.0.2"
 def DEFAULT_TARGET_SDK_VERSION              = 22
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "+"

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -67,10 +67,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   private String getCurrentLanguage() {
-    int sdkVerionAndroidN = 24;
-
     Locale current;
-    if (Build.VERSION.SDK_INT >= sdkVerionAndroidN) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       current = getReactApplicationContext().getResources().getConfiguration().getLocales().get(0);
     } else {
       current = getReactApplicationContext().getResources().getConfiguration().locale;
@@ -90,10 +88,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   private String getCurrentCountry() {
-    int sdkVerionAndroidN = 24;
-
     Locale current;
-    if (Build.VERSION.SDK_INT >= sdkVerionAndroidN) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       current = getReactApplicationContext().getResources().getConfiguration().getLocales().get(0);
     } else {
       current = getReactApplicationContext().getResources().getConfiguration().locale;

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -67,8 +67,10 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   private String getCurrentLanguage() {
+    int sdkVerionAndroidN = 24;
+
     Locale current;
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+    if (Build.VERSION.SDK_INT >= sdkVerionAndroidN) {
       current = getReactApplicationContext().getResources().getConfiguration().getLocales().get(0);
     } else {
       current = getReactApplicationContext().getResources().getConfiguration().locale;
@@ -88,8 +90,10 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   private String getCurrentCountry() {
+    int sdkVerionAndroidN = 24;
+
     Locale current;
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+    if (Build.VERSION.SDK_INT >= sdkVerionAndroidN) {
       current = getReactApplicationContext().getResources().getConfiguration().getLocales().get(0);
     } else {
       current = getReactApplicationContext().getResources().getConfiguration().locale;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixed issue #459

<!-- OR, if you're implementing a new feature: -->

### How to reproduce
* When I created react-native app from `create-react-native-app`, android build is fail.
<img width="1145" alt="2018-07-29 3 10 42" src="https://user-images.githubusercontent.com/6203798/43363545-27564596-9342-11e8-935a-02977e2b6712.png">


### Solution
* `Build.VERSION_CODES.N` and `getLocales()` is availabed in from Android SDK 24. Thus, `compileSdkVersion` should be at least 24.
<img width="551" alt="2018-07-29 3 11 31" src="https://user-images.githubusercontent.com/6203798/43363547-2cbc4562-9342-11e8-80ac-03078206e6a0.png">


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`.
* [X] I mentionned this change in `CHANGELOG.md`.
