### PR TITLE
chore: Ignore the Android build/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .vscode
 .DS_Store
+android/build/
 
 # Xcode
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release Notes
 
 ### next
+ * Shrank the npm package size (https://github.com/rebeccahughes/react-native-device-info/issues/477)
 
 ### 0.22.3
  * Fixed `eslint-plugin-import` error (https://github.com/rebeccahughes/react-native-device-info/pull/466)


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

The currently published nom package (v0.22.3) is 28.2 MB, unpacked, because it includes a copy of the generated Android build files. By ignoring the folder `android/build` in `.gitignore`, npm will also ignore that folder, and the build artifacts will no longer wind up on in the npm package.

Before: 28.2 MB
After: 187.9 kB

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

* [x] I have tested this on a device/simulator for each compatible OS (Android).
* [ ] (N/A) I added the documentation in `README.md`.
* [x] I mentionned this change in `CHANGELOG.md`.