### PR TITLE
fix(deviceinfo.d.ts): fix typescript declaration export

### DIFF
--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -1,42 +1,44 @@
 // should be imported this way:
-// import * as DeviceInfo from 'react-native-device-info';
+// import DeviceInfo from 'react-native-device-info';
 
-export function getUniqueID(): string;
-export function getManufacturer(): string;
-export function getBrand(): string;
-export function getModel(): string;
-export function getDeviceId(): string;
-export function getSystemName(): string;
-export function getSystemVersion(): string;
-export function getBundleId(): string;
-export function getApplicationName(): string;
-export function getBuildNumber(): string;
-export function getVersion(): string;
-export function getReadableVersion(): string;
-export function getDeviceName(): string;
-export function getUserAgent(): string;
-export function getDeviceLocale(): string;
-export function getDeviceCountry(): string;
-export function getTimezone(): string;
-export function getInstanceID(): string;
-export function getInstallReferrer(): string;
-export function isEmulator(): boolean;
-export function isTablet(): boolean;
-export function getFontScale(): number;
-export function is24Hour(): boolean;
-export function isPinOrFingerprintSet(): (
-  cb: (isPinOrFingerprintSet: boolean) => void
-) => void;
-export function getFirstInstallTime(): number;
-export function getLastUpdateTime(): number;
-export function getSerialNumber(): string;
-export function getIPAddress(): Promise<string>;
-export function getMACAddress(): Promise<string>;
-export function getPhoneNumber(): string;
-export function getAPILevel(): number;
-export function getCarrier(): string;
-export function getTotalMemory(): number;
-export function getMaxMemory(): number;
-export function getTotalDiskCapacity(): number;
-export function getFreeDiskStorage(): number;
-export function getBatteryLevel(): Promise<number>;
+declare const _default: {
+  getUniqueID: () => string;
+  getManufacturer: () => string;
+  getBrand: () => string;
+  getModel: () => string;
+  getDeviceId: () => string;
+  getSystemName: () => string;
+  getSystemVersion: () => string;
+  getBundleId: () => string;
+  getApplicationName: () => string;
+  getBuildNumber: () => string;
+  getVersion: () => string;
+  getReadableVersion: () => string;
+  getDeviceName: () => string;
+  getUserAgent: () => string;
+  getDeviceLocale: () => string;
+  getDeviceCountry: () => string;
+  getTimezone: () => string;
+  getInstanceID: () => string;
+  getInstallReferrer: () => string;
+  isEmulator: () => boolean;
+  isTablet: () => boolean;
+  getFontScale: () => number;
+  is24Hour: () => boolean;
+  isPinOrFingerprintSet: (cb: (isPinOrFingerprintSet: boolean) => void) => void;
+  getFirstInstallTime: () => number;
+  getLastUpdateTime: () => number;
+  getSerialNumber: () => string;
+  getIPAddress: () => Promise<string>
+  getMACAddress: () => Promise<string>
+  getPhoneNumber: () => string;
+  getAPILevel: () => number;
+  getCarrier: () => string;
+  getTotalMemory: () => number;
+  getMaxMemory: () => number;
+  getTotalDiskCapacity: () => number;
+  getFreeDiskStorage: () => number;
+  getBatteryLevel: () => Promise<number>
+};
+
+export default _default;


### PR DESCRIPTION
## Description

In #466 the export of the main module was changed to use default export.
Change the typescript declaration to use default export, too.

## Checklist

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
