### PR TITLE
Add iPhone XR, iPhone XS iPhone XS Max device models to a getModels function

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -103,6 +103,9 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
                               @"iPhone9,4" :@"iPhone 7 Plus",   // (model A1784 | Global)
                               @"iPhone10,3":@"iPhone X",        // (model A1865, A1902)
                               @"iPhone10,6":@"iPhone X",        // (model A1901)
+                              @"iPhone11,8":@"iPhone XR",       // (model A1882, A1719)
+                              @"iPhone11,2":@"iPhone XS",       //
+                              @"iPhone11,4":@"iPhone XS Max",   //
                               @"iPhone10,1":@"iPhone 8",        // (model A1863, A1906, A1907)
                               @"iPhone10,4":@"iPhone 8",        // (model A1905)
                               @"iPhone10,2":@"iPhone 8 Plus",   // (model A1864, A1898, A1899)


### PR DESCRIPTION
## Description

Fixed issue #493 

