### PR TITLE
fixed android getFreeDiskStorage and getTotalDiskCapacity got negative number

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.lang.Runtime;
 import java.net.NetworkInterface;
-
+import java.io.File;
 import javax.annotation.Nullable;
 
 public class RNDeviceModule extends ReactContextBaseJavaModule {
@@ -190,10 +190,13 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public Integer getTotalDiskCapacity() {
+  public long getTotalDiskCapacity() {
     try {
-      StatFs root = new StatFs(Environment.getRootDirectory().getAbsolutePath());
-      return root.getBlockCount() * root.getBlockSize();
+      File sdcardDir = Environment.getExternalStorageDirectory();
+      StatFs statFs = new StatFs(sdcardDir.getPath());
+      long blockSize = statFs.getBlockSizeLong();
+      long totalSize = statFs.getBlockCountLong();
+      return blockSize * totalSize;
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -201,10 +204,13 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public Integer getFreeDiskStorage() {
+  public long getFreeDiskStorage() {
     try {
-      StatFs external = new StatFs(Environment.getExternalStorageDirectory().getAbsolutePath());
-      return external.getAvailableBlocks() * external.getBlockSize();
+      File path = Environment.getExternalStorageDirectory();
+      StatFs statFs = new StatFs(path.getPath());
+      long blockSize = statFs.getBlockSizeLong();
+      long availableBlocks = statFs.getAvailableBlocksLong();
+      return blockSize * availableBlocks;
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
fixed android getFreeDiskStorage and getTotalDiskCapacity got negative number

## Description

Fixed issue #331 #346 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |
| Windows |    ✅❌     |

## Checklist


* [x] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.