### PR TITLE
build: Update build.gradle to remove compile warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,6 @@ android {
 dependencies {
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
 
-    compile 'com.facebook.react:react-native:+'
-    compile "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
## Description

With the latest react-native version RN >= 0.57 the android build tools were updated and now using compile in the build.gradle file generates the following error:
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
Please note that this also happens to people that manually updated their android build tools from the previous defaults

## Compatibility

This is a change in the android/build.gradle file that only affects android builds, it doesn't add or remove functionality.

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.

Items 2 and 3 in the checklist are not needed as this change doesn't affect any functionality. It just removes a compile warning.