### PR TITLE
fix(docs): gradle compile config depreciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Run your project (Cmd+R)
 ```diff
 dependencies {
     ...
-    compile "com.facebook.react:react-native:+"  // From node_modules
-+   compile project(':react-native-device-info')
+    implementation "com.facebook.react:react-native:+"  // From node_modules
++   implementation project(':react-native-device-info')
 }
 ```
 


### PR DESCRIPTION
## Description

PR facebook/react-native#20767 bumped the version of the Android
Gradle Plugin to v3 which uses the newer Gradle dependency
configurations `implementation` and `api` which make `compile`
obsolete.

PR facebook/react-native#20853 covered the `link` command.

Using `compile` will result in a warning message during app build and
`compile` will be eventually removed by Gradle.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

* [ ] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`.
* [ ] I mentionned this change in `CHANGELOG.md`.
