### PR TITLE
compare hasNotch devices with lowercase

### DIFF
--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -207,7 +207,7 @@ export default {
     return RNDeviceInfo.isPinOrFingerprintSet;
   },
   hasNotch: function() {
-    return devicesWithNotch.findIndex(item => item.brand === RNDeviceInfo.brand && item.model === RNDeviceInfo.model) !== -1;
+    return devicesWithNotch.findIndex(item => item.brand.toLowerCase() === RNDeviceInfo.brand.toLowerCase() && item.model.toLowerCase() === RNDeviceInfo.model.toLowerCase()) !== -1;
   },
   getFirstInstallTime: function() {
     return RNDeviceInfo.firstInstallTime;


### PR DESCRIPTION
## Description

To have a more robust code we should compare brand and model after using lowercase
Please tell me what you think of it

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [ x ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentioned this change in `CHANGELOG.md`.
