### PR TITLE
Remove React dependency from podspec

### DIFF
--- a/RNDeviceInfo.podspec
+++ b/RNDeviceInfo.podspec
@@ -13,6 +13,4 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/rebeccahughes/react-native-device-info.git" }
 
   s.source_files  = "ios/RNDeviceInfo/*.{h,m}"
-
-  s.dependency 'React'
 end


### PR DESCRIPTION
It is deprecated and makes error as #38 .

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixed issue #38

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item: [X] -->

* [X ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentioned this change in `CHANGELOG.md`.
