### PR TITLE
feat(android/ios): Adding getDeviceType function and changing behavior of isTablet

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ import DeviceInfo from 'react-native-device-info';
 | [isTablet()](#istablet)                           | `boolean`           |  ✅  |   ✅    |   ✅    | ?      |
 | [hasNotch()](#hasNotch)                           | `boolean`           |  ✅  |   ✅    |   ✅    | 0.23.0 |
 | [isLandscape()](#isLandscape)                     | `boolean`           |  ✅  |   ✅    |   ✅    | 0.24.0 |
+| [getDeviceType()](#getDeviceType)                 | `string`            |  ✅  |   ✅    |   ❌    | ?      |
 
 ---
 
@@ -887,6 +888,21 @@ Tells if the device has a notch.
 ```js
 const hasNotch = DeviceInfo.hasNotch(); // true
 ```
+
+### getDeviceType()
+
+Returns the device's type as a string, which will be one of:
+* `Handset`
+* `Tablet`
+* `Tv`
+* `Unknown`
+
+**Examples**
+
+```js
+const deviceType = DeviceInfo.getDeviceType(); // 'Handset'
+```
+
 
 ## Troubleshooting
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/DeviceType.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/DeviceType.java
@@ -1,0 +1,18 @@
+package com.learnium.RNDeviceInfo;
+
+public enum DeviceType {
+    HANDSET ("Handset"),
+    TABLET ("Tablet"),
+    TV ("Tv"),
+    UNKNOWN ("Unknown");
+
+    private final String value;
+
+    DeviceType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -2,13 +2,13 @@ package com.learnium.RNDeviceInfo;
 
 import android.Manifest;
 import android.app.KeyguardManager;
+import android.app.UiModeManager;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageInfo;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.net.wifi.WifiManager;
@@ -18,7 +18,7 @@ import android.os.Environment;
 import android.os.StatFs;
 import android.os.BatteryManager;
 import android.provider.Settings;
-import android.provider.Settings.Secure;
+import android.view.WindowManager;
 import android.webkit.WebSettings;
 import android.telephony.TelephonyManager;
 import android.text.format.Formatter;
@@ -48,10 +48,13 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
 
   WifiInfo wifiInfo;
 
+  DeviceType deviceType;
+
   public RNDeviceModule(ReactApplicationContext reactContext) {
     super(reactContext);
 
     this.reactContext = reactContext;
+    this.deviceType = getDeviceType(reactContext);
   }
 
   @Override
@@ -111,20 +114,50 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   private Boolean isTablet() {
-    int layout = getReactApplicationContext().getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK;
-    if (layout != Configuration.SCREENLAYOUT_SIZE_LARGE && layout != Configuration.SCREENLAYOUT_SIZE_XLARGE) {
-      return false;
+    return deviceType == DeviceType.TABLET;
+  }
+
+  private static DeviceType getDeviceType(ReactApplicationContext reactContext) {
+    // Detect TVs via ui mode (Android TVs) or system features (Fire TV).
+    if (reactContext.getApplicationContext().getPackageManager().hasSystemFeature("amazon.hardware.fire_tv")) {
+      return DeviceType.TV;
     }
 
-    final DisplayMetrics metrics = getReactApplicationContext().getResources().getDisplayMetrics();
-    if (metrics.densityDpi == DisplayMetrics.DENSITY_DEFAULT
-            || metrics.densityDpi == DisplayMetrics.DENSITY_HIGH
-            || metrics.densityDpi == DisplayMetrics.DENSITY_MEDIUM
-            || metrics.densityDpi == DisplayMetrics.DENSITY_TV
-            || metrics.densityDpi == DisplayMetrics.DENSITY_XHIGH) {
-      return true;
+    UiModeManager uiManager = (UiModeManager) reactContext.getSystemService(Context.UI_MODE_SERVICE);
+    if (uiManager != null && uiManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
+      return DeviceType.TV;
     }
-    return false;
+
+    // Find the current window manager, if none is found we can't measure the device physical size.
+    WindowManager windowManager = (WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE);
+    if (windowManager == null) {
+      return DeviceType.UNKNOWN;
+    }
+
+    // Get display metrics to see if we can differentiate handsets and tablets.
+    // NOTE: for API level 16 the metrics will exclude window decor.
+    DisplayMetrics metrics = new DisplayMetrics();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      windowManager.getDefaultDisplay().getRealMetrics(metrics);
+    } else {
+      windowManager.getDefaultDisplay().getMetrics(metrics);
+    }
+
+    // Calculate physical size.
+    double widthInches = metrics.widthPixels / (double) metrics.xdpi;
+    double heightInches = metrics.widthPixels / (double) metrics.xdpi;
+    double diagonalSizeInches = Math.sqrt(Math.pow(widthInches, 2) + Math.pow(heightInches, 2));
+
+    if (diagonalSizeInches >= 3.0 && diagonalSizeInches <= 6.9) {
+      // Devices in a sane range for phones are considered to be Handsets.
+      return DeviceType.HANDSET;
+    } else if (diagonalSizeInches > 6.9 && diagonalSizeInches <= 18.0) {
+      // Devices larger than handset and in a sane range for tablets are tablets.
+      return DeviceType.TABLET;
+    } else {
+      // Otherwise, we don't know what device type we're on/
+      return DeviceType.UNKNOWN;
+    }
   }
 
   private float fontScale() {
@@ -181,7 +214,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       }
     }
 
-    p.resolve(macAddress);    
+    p.resolve(macAddress);
   }
 
   @ReactMethod
@@ -329,6 +362,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
     ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
     actMgr.getMemoryInfo(memInfo);
     constants.put("totalMemory", memInfo.totalMem);
+    constants.put("deviceType", deviceType.getValue());
 
     return constants;
   }

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -1,6 +1,8 @@
 // should be imported this way:
 // import DeviceInfo from 'react-native-device-info';
 
+export type DeviceType = 'Handset' | 'Tablet' | 'Tv' | 'Unknown';
+
 declare const _default: {
   getUniqueID: () => string;
   getManufacturer: () => string;
@@ -30,8 +32,8 @@ declare const _default: {
   getFirstInstallTime: () => number;
   getLastUpdateTime: () => number;
   getSerialNumber: () => string;
-  getIPAddress: () => Promise<string>
-  getMACAddress: () => Promise<string>
+  getIPAddress: () => Promise<string>;
+  getMACAddress: () => Promise<string>;
   getPhoneNumber: () => string;
   getAPILevel: () => number;
   getCarrier: () => string;
@@ -40,8 +42,9 @@ declare const _default: {
   getTotalDiskCapacity: () => number;
   getFreeDiskStorage: () => number;
   getBatteryLevel: () => Promise<number>;
-  isLandscape: () => boolean;    
+  isLandscape: () => boolean;
   isAirPlaneMode: () => Promise<boolean>;
+  getDeviceType: () => DeviceType;
 };
 
 export default _default;

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -281,5 +281,8 @@ export default {
   },
   isAirPlaneMode: function() {
     return RNDeviceInfo.isAirPlaneMode();
-  }
+  },
+  getDeviceType: function() {
+    return RNDeviceInfo.deviceType;
+  },
 };

--- a/deviceinfo.js.flow
+++ b/deviceinfo.js.flow
@@ -1,5 +1,7 @@
 // @flow
 
+export type DeviceType = 'Handset' | 'Tablet' | 'Tv' | 'Unknown';
+
 declare module.exports: {
   getUniqueID: () => string,
   getManufacturer: () => string,
@@ -43,4 +45,5 @@ declare module.exports: {
   getBatteryLevel: () => Promise<number>,
   isLandscape: () => boolean,
   isAirPlaneMode: () => Promise<boolean>,
+  getDeviceType: () => DeviceType,
 };

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -14,6 +14,15 @@
 #import <LocalAuthentication/LocalAuthentication.h>
 #endif
 
+typedef NS_ENUM(NSInteger, DeviceType) {
+    DeviceTypeHandset,
+    DeviceTypeTablet,
+    DeviceTypeTv,
+    DeviceTypeUnknown
+};
+
+#define DeviceTypeValues [NSArray arrayWithObjects: @"Handset", @"Tablet", @"Tv", @"Unknown", nil]
+
 @interface RNDeviceInfo()
 @property (nonatomic) bool isEmulator;
 @end
@@ -203,9 +212,19 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
   return currentTimeZone.name;
 }
 
+- (DeviceType) getDeviceType
+{
+    switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
+        case UIUserInterfaceIdiomPhone: return DeviceTypeHandset;
+        case UIUserInterfaceIdiomPad: return DeviceTypeTablet;
+        case UIUserInterfaceIdiomTV: return DeviceTypeTv;
+        default: return DeviceTypeUnknown;
+    }
+}
+
 - (bool) isTablet
 {
-  return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
+  return [self getDeviceType] == DeviceTypeTablet;
 }
 
 // Font scales based on font sizes from https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/
@@ -298,6 +317,7 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
              @"totalMemory": @(self.totalMemory),
              @"totalDiskCapacity": @(self.totalDiskCapacity),
              @"freeDiskStorage": @(self.freeDiskStorage),
+             @"deviceType": [DeviceTypeValues objectAtIndex: [self getDeviceType]],
              };
 }
 

--- a/web/index.js
+++ b/web/index.js
@@ -39,5 +39,6 @@ module.exports = {
   totalDiskCapacity: 0,
   freeDiskStorage: 0,
   getBatteryLevel: () => Promise.resolve(0),
-  isLandscape: false
+  isLandscape: false,
+  deviceType: 'Unknown',
 };


### PR DESCRIPTION
## Description

- getDeviceType will return: Handset, Tablet, Tv, or Unknown
- Supported on iOS and Android.  Always set to Unknown on web. Unsupported on windows
- On iOS/Android, modified isTablet logic to just check if deviceType == Tablet

On iOS, device type detection is done via user interface idiom detection for the device and is thus exact.

On Android, TV platform detection checks for both Android TVs (via UI manager mode) and FireTVs (via system feature check). For non TV devices we attempt to calculate the physical screen size (diagonal) and set some sane cutoffs for when a device is a Handset (3" -> 6.9") or a Tablet (7" -> 18"). If detection fails the deviceType is set to Unknown.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

* [X] I have tested this on a device/simulator for each compatible OS
* [X] I added the documentation in `README.md`.
* [ ] I mentioned this change in `CHANGELOG.md`.
