### PR TITLE
hasNotch should return true for Pocophone F1

### DIFF
--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -176,6 +176,10 @@ const devicesWithNotch = [
   },
   {
     brand: 'xiaomi',
+    model: 'POCO F1',
+  },
+  {
+    brand: 'xiaomi',
     model: 'POCOPHONE F1',
   },
   {

--- a/deviceinfo.js
+++ b/deviceinfo.js
@@ -176,7 +176,7 @@ const devicesWithNotch = [
   },
   {
     brand: 'xiaomi',
-    model: 'POCO F1',
+    model: 'POCOPHONE F1',
   },
   {
     brand: 'xiaomi',


### PR DESCRIPTION
Fixed issue #581 

`DeviceInfo.getModel()` returns `'POCOPHONE F1'`, however currently this is getting matched against `'POCO F1'`, which evaluates to `false`. This fixes it.
