### PR TITLE
Use BigInteger to avoid overflow (Fixes #331)

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.lang.Runtime;
 import java.net.NetworkInterface;
+import java.math.BigInteger;
 
 import javax.annotation.Nullable;
 
@@ -224,10 +225,10 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public Integer getTotalDiskCapacity() {
+  public BigInteger getTotalDiskCapacity() {
     try {
       StatFs root = new StatFs(Environment.getRootDirectory().getAbsolutePath());
-      return root.getBlockCount() * root.getBlockSize();
+      return BigInteger.valueOf(root.getBlockCount()).multiply(BigInteger.valueOf(root.getBlockSize()));
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -235,10 +236,10 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public Integer getFreeDiskStorage() {
+  public BigInteger getFreeDiskStorage() {
     try {
       StatFs external = new StatFs(Environment.getExternalStorageDirectory().getAbsolutePath());
-      return external.getAvailableBlocks() * external.getBlockSize();
+      return BigInteger.valueOf(external.getAvailableBlocks()).multiply(BigInteger.valueOf(external.getBlockSize()));
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -27,7 +27,7 @@ declare const _default: {
   isTablet: () => boolean;
   getFontScale: () => number;
   is24Hour: () => boolean;
-  isPinOrFingerprintSet: (cb: (isPinOrFingerprintSet: boolean) => void) => void;
+  isPinOrFingerprintSet(): (cb: (isPinOrFingerprintSet: boolean) => void) => void;
   hasNotch: () => boolean;
   getFirstInstallTime: () => number;
   getLastUpdateTime: () => number;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixed issue #331 

There are other PRs floating around for this one but they are all messy or abandoned or both.

This is a very focused change that changes the use of the existing native API calls (which are deprecated but also work back to the react-native supported API16) so that they are computed with protection against integer overflow per this comment from @knot123: https://github.com/rebeccahughes/react-native-device-info/issues/331#issuecomment-428848892

There are valid reasons why you might want to use different native API calls to total up space in Android but you could also argue those are all behavior changes for this module API, so this just fixes the overflow and leaves it at that

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for android (it's an android fix)
* [ ] I added the documentation in `README.md`.
* [ ] I mentioned this change in `CHANGELOG.md`.
