### PR TITLE
Alter isPinOrFingerprintSet typing so it is a function

### DIFF
--- a/deviceinfo.d.ts
+++ b/deviceinfo.d.ts
@@ -27,7 +27,7 @@ declare const _default: {
   isTablet: () => boolean;
   getFontScale: () => number;
   is24Hour: () => boolean;
-  isPinOrFingerprintSet: (cb: (isPinOrFingerprintSet: boolean) => void) => void;
+  isPinOrFingerprintSet(): (cb: (isPinOrFingerprintSet: boolean) => void) => void;
   hasNotch: () => boolean;
   getFirstInstallTime: () => number;
   getLastUpdateTime: () => number;


### PR DESCRIPTION
## Description

A simple typing fix. I'm not the best at Typescript definitions, but this small change results in Typescript transpiling code that looks like the readme with no issues, and I have verified the callback is being called on a real device

Fixes #486


## Checklist

<!-- Check completed item: [X] -->

* [ ] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`.
* [ ] I mentioned this change in `CHANGELOG.md`.
